### PR TITLE
マウスキーを押すまでAMLに留まる・デフォルトのキーマップ変更

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
@@ -36,4 +36,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAP_CODE_DELAY 5
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
-#define AUTO_MOUSE_DEFAULT_LAYER 1
+#define AUTO_MOUSE_DEFAULT_LAYER 2

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
@@ -36,4 +36,5 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define TAP_CODE_DELAY 5
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
-#define AUTO_MOUSE_DEFAULT_LAYER 2
+#define AUTO_MOUSE_DEFAULT_LAYER 4
+#define AUTO_MOUSE_LAYER_KEEP_TIME 30000

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/config.h
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #define TAP_CODE_DELAY 5
+#define DYNAMIC_KEYMAP_LAYER_COUNT 5
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE
 #define AUTO_MOUSE_DEFAULT_LAYER 4

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/via/keymap.c
@@ -24,17 +24,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // keymap for default (VIA)
   [0] = LAYOUT_universal(
-    KC_Q     , KC_W     , KC_E     , KC_R     , KC_T     ,                            KC_Y     , KC_U     , KC_I     , KC_O     , KC_P     ,
-    KC_A     , KC_S     , KC_D     , KC_F     , KC_G     ,                            KC_H     , KC_J     , KC_K     , KC_L     , KC_MINS  ,
-    KC_Z     , KC_X     , KC_C     , KC_V     , KC_B     ,                            KC_N     , KC_M     , KC_COMM  , KC_DOT   , KC_SLSH  ,
-    KC_LCTL  , KC_LGUI  , KC_LALT  ,LSFT_T(KC_LNG2),LT(1,KC_SPC),LT(3,KC_LNG1),KC_BSPC,LT(2,KC_ENT),LSFT_T(KC_LNG2),KC_RALT,KC_RGUI, KC_RSFT
+    KC_Q           , KC_W           , KC_E           , KC_R           , KC_T           ,                                    KC_Y           , KC_U           , KC_I           , KC_O           , KC_P           ,
+    LCTL_T(KC_A)   , KC_S           , KC_D           , KC_F           , KC_G           ,                                    KC_H           , KC_J           , KC_K           , KC_L           , RCTL_T(KC_ENT) ,
+    LSFT_T(KC_Z)   , KC_X           , LALT_T(KC_C)   , LCMD_T(KC_V)   , KC_B           ,                                    KC_N           , RCMD_T(KC_M)   , KC_COMM        , KC_DOT         , RSFT_T(KC_MINS),
+    KC_ESC         , KC_LGUI        , KC_LALT        , LCMD_T(KC_LNG2), LT(1,KC_SPC)   ,  LT(3,KC_TAB)   , KC_BSPC        , LT(2,KC_LNG1)  , LSFT_T(KC_LNG2), KC_RALT        , KC_RGUI        , MO(2)
   ),
 
   [1] = LAYOUT_universal(
     KC_F1    , KC_F2    , KC_F3    , KC_F4    , KC_RBRC  ,                            KC_F6    , KC_F7    , KC_F8    , KC_F9    , KC_F10   ,
     KC_F5    , KC_EXLM  , S(KC_6)  ,S(KC_INT3), S(KC_8)  ,                           S(KC_INT1), KC_BTN1  , KC_PGUP  , KC_BTN2  , KC_SCLN  ,
     S(KC_EQL),S(KC_LBRC),S(KC_7)   , S(KC_2)  ,S(KC_RBRC),                            KC_LBRC  , KC_DLR   , KC_PGDN  , KC_BTN3  , KC_F11   ,
-    KC_INT1  , KC_EQL   , S(KC_3)  , _______  , _______  , _______  ,      TO(2)    , TO(0)    , _______  , KC_RALT  , KC_RGUI  , KC_F12
+    KC_INT1  , KC_EQL   , S(KC_3)  , _______  , _______  , _______  ,      _______    , _______    , _______  , KC_RALT  , KC_RGUI  , KC_F12
   ),
 
   [2] = LAYOUT_universal(
@@ -50,12 +50,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     RGB_RMOD , RGB_HUD  , RGB_SAD  , RGB_VAD  , SCRL_DVD ,                            CPI_D1K  , CPI_D100 , CPI_I100 , CPI_I1K  , KBC_SAVE ,
     QK_BOOT  , KBC_RST  , _______  , _______  , _______  , _______  ,      _______  , _______  , _______  , _______  , KBC_RST  , QK_BOOT
   ),
+
+  [4] = LAYOUT_universal(
+    KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,                            KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,
+    G(KC_A), G(KC_S), KC_NO  , KC_NO  , KC_NO  ,                            KC_NO  , KC_BTN1, KC_BTN3, KC_BTN2, KC_NO  ,
+    G(KC_Z), G(KC_X), G(KC_C), G(KC_V), KC_NO  ,                            KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,
+    KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  ,          KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO  , KC_NO
+  ),
 };
 // clang-format on
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-    // Auto enable scroll mode when the highest layer is 3
-    keyball_set_scroll_mode(get_highest_layer(state) == 3);
+    // Check if layer 3 is active
+    keyball_set_scroll_mode((state & (1 << 3)) != 0);
+    #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+      keyball_handle_auto_mouse_layer_change(state);
+    #endif
     return state;
 }
 
@@ -73,23 +83,14 @@ void oledkit_render_info_user(void) {
 bool get_retro_tapping(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case LGUI_T(KC_LNG2):
-      return true;
     case LT(1, KC_SPC):
-      return true;
     case LT(2, KC_LNG1):
-      return true;
     case LSFT_T(KC_Z):
-      return true;
     case LCTL_T(KC_A):
-      return true;
     case LALT_T(KC_C):
-      return true;
     case CMD_T(KC_V):
-      return true;
     case RCTL_T(KC_ENT):
-      return true;
     case RSFT_T(KC_MINS):
-      return true;
     case RGUI_T(KC_M):
       return true;
     default:

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.c
@@ -33,6 +33,8 @@ const uint16_t AML_TIMEOUT_MIN = 100;
 const uint16_t AML_TIMEOUT_MAX = 1000;
 const uint16_t AML_TIMEOUT_QU  = 50;   // Quantization Unit
 
+const uint32_t AML_ACTIVATE_THRESHOLD = 50;
+
 static const char BL = '\xB0'; // Blank indicator character
 static const char LFSTR_ON[] PROGMEM = "\xB2\xB3";
 static const char LFSTR_OFF[] PROGMEM = "\xB4\xB5";
@@ -50,6 +52,9 @@ keyball_t keyball = {
 
     .scroll_mode = false,
     .scroll_div  = 0,
+
+    .last_layer_state = 0,
+    .total_mouse_movement = 0,
 
     .pressing_keys = { BL, BL, BL, BL, BL, BL, 0 },
 };
@@ -263,6 +268,45 @@ static inline bool should_report(void) {
 #endif
     return true;
 }
+
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+static uint16_t keyball_get_auto_mouse_timeout(void) {
+    return keyball.auto_mouse_layer_timeout;
+}
+
+static void keyball_set_auto_mouse_timeout(uint16_t timeout) {
+    keyball.auto_mouse_layer_timeout = timeout;
+}
+
+static uint16_t get_auto_mouse_keep_time(void) {
+#ifdef AUTO_MOUSE_LAYER_KEEP_TIME
+        return AUTO_MOUSE_LAYER_KEEP_TIME;
+#else
+        return keyball_get_auto_mouse_timeout();
+#endif
+}
+
+static uint16_t movement_size_of(report_mouse_t *rep) {
+    return abs(rep->x) + abs(rep->y);
+}
+
+// override qmk function:
+//  https://github.com/qmk/qmk_firmware/blob/0.22.14/quantum/pointing_device/pointing_device_auto_mouse.c#L208-L221
+// activate auto mouse layer when mouse movement exceeds the threshold.
+bool auto_mouse_activation(report_mouse_t mouse_report) {
+    keyball.total_mouse_movement += movement_size_of(&mouse_report);
+    if (AML_ACTIVATE_THRESHOLD < keyball.total_mouse_movement) {
+        keyball.total_mouse_movement = 0;
+        if (get_auto_mouse_timeout() != get_auto_mouse_keep_time()) {
+            // keep AML if mouse is moving with "short timeout".
+            set_auto_mouse_timeout(get_auto_mouse_keep_time());
+        }
+        return true;
+    } else {
+        return mouse_report.buttons;
+    }
+}
+#endif
 
 report_mouse_t pointing_device_driver_get_report(report_mouse_t rep) {
     // fetch from optical sensor.
@@ -503,7 +547,7 @@ void keyball_oled_render_layerinfo(void) {
         oled_write_P(LFSTR_OFF, false);
     }
 
-    oled_write(format_4d(get_auto_mouse_timeout() / 10) + 1, false);
+    oled_write(format_4d(keyball_get_auto_mouse_timeout() / 10) + 1, false);
     oled_write_char('0', false);
 #    else
     oled_write_P(PSTR("\xC2\xC3\xB4\xB5 ---"), false);
@@ -562,6 +606,21 @@ void keyball_set_cpi(uint8_t cpi) {
     }
 }
 
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+void keyball_handle_auto_mouse_layer_change(layer_state_t state) {
+    layer_state_t last_state = keyball.last_layer_state;
+    // go into AML
+    if (!layer_state_cmp(last_state, AUTO_MOUSE_DEFAULT_LAYER) && layer_state_cmp(state, AUTO_MOUSE_DEFAULT_LAYER)) {
+        keyball.total_mouse_movement = 0;
+    } // go out AML
+    else if (layer_state_cmp(last_state, AUTO_MOUSE_DEFAULT_LAYER) && !layer_state_cmp(state, AUTO_MOUSE_DEFAULT_LAYER)) {
+        set_auto_mouse_timeout(get_auto_mouse_keep_time());
+        keyball.total_mouse_movement = 0;
+    }
+    keyball.last_layer_state = state;
+}
+#endif
+
 //////////////////////////////////////////////////////////////////////////////
 // Keyboard hooks
 
@@ -582,7 +641,7 @@ void keyboard_post_init_kb(void) {
         keyball_set_scroll_div(c.sdiv);
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
         set_auto_mouse_enable(c.amle);
-        set_auto_mouse_timeout(c.amlto == 0 ? AUTO_MOUSE_TIME : (c.amlto + 1) * AML_TIMEOUT_QU);
+        keyball_set_auto_mouse_timeout(c.amlto == 0 ? AUTO_MOUSE_TIME : (c.amlto + 1) * AML_TIMEOUT_QU);
 #endif
 #if KEYBALL_SCROLLSNAP_ENABLE == 2
         keyball_set_scrollsnap_mode(c.ssnap);
@@ -651,6 +710,14 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
         keycode &= 0xff;
     }
 
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+    // reduce auto mouse timeout if mouse key is pressed.
+    if ((is_mouse_record_kb(keycode, record) || IS_MOUSEKEY(keycode)) && record->event.pressed) {
+        set_auto_mouse_timeout(keyball_get_auto_mouse_timeout());
+        keyball.total_mouse_movement = 0;
+    }
+#endif
+
     switch (keycode) {
 #ifndef MOUSEKEY_ENABLE
         // process KC_MS_BTN1~8 by myself
@@ -687,7 +754,7 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                     .sdiv  = keyball.scroll_div,
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
                     .amle  = get_auto_mouse_enable(),
-                    .amlto = (get_auto_mouse_timeout() / AML_TIMEOUT_QU) - 1,
+                    .amlto = (keyball_get_auto_mouse_timeout() / AML_TIMEOUT_QU) - 1,
 #endif
 #if KEYBALL_SCROLLSNAP_ENABLE == 2
                     .ssnap = keyball_get_scrollsnap_mode(),
@@ -737,14 +804,14 @@ bool process_record_kb(uint16_t keycode, keyrecord_t *record) {
                 break;
             case AML_I50:
                 {
-                    uint16_t v = get_auto_mouse_timeout() + 50;
-                    set_auto_mouse_timeout(MIN(v, AML_TIMEOUT_MAX));
+                    uint16_t v = keyball_get_auto_mouse_timeout() + 50;
+                    keyball_set_auto_mouse_timeout(MIN(v, AML_TIMEOUT_MAX));
                 }
                 break;
             case AML_D50:
                 {
-                    uint16_t v = get_auto_mouse_timeout() - 50;
-                    set_auto_mouse_timeout(MAX(v, AML_TIMEOUT_MIN));
+                    uint16_t v = keyball_get_auto_mouse_timeout() - 50;
+                    keyball_set_auto_mouse_timeout(MAX(v, AML_TIMEOUT_MIN));
                 }
                 break;
 #endif

--- a/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
+++ b/qmk_firmware/keyboards/keyball/lib/keyball/keyball.h
@@ -177,6 +177,10 @@ typedef struct {
     keypos_t       last_pos;
     report_mouse_t last_mouse;
 
+    uint16_t auto_mouse_layer_timeout;
+    layer_state_t last_layer_state;
+    uint16_t total_mouse_movement;
+
     // Buffer to indicate pressing keys.
     char pressing_keys[KEYBALL_OLED_MAX_PRESSING_KEYCODES + 1];
 } keyball_t;
@@ -270,3 +274,7 @@ uint8_t keyball_get_cpi(void);
 /// In addition, if you do not upload SROM, the maximum value will be limited
 /// to 35 (3500CPI).
 void keyball_set_cpi(uint8_t cpi);
+
+#ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
+void keyball_handle_auto_mouse_layer_change(layer_state_t state);
+#endif


### PR DESCRIPTION
https://github.com/negokaz/keyball/pull/2

AML専用レイヤーを追加

初期keymapを、普段つかっているものに変更

retro keysのswitch文の冗長な表記を削除